### PR TITLE
Fix cljs build preparation. Update dependencies.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,19 +3,19 @@
   :url "https://github.com/weavejester/duct-figwheel-component"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [suspendable "0.1.1"]
-                 [figwheel-sidecar "0.5.8"]
+                 [figwheel-sidecar "0.5.14"]
                  [http-kit "2.2.0"]
                  [com.cemerick/piggieback "0.2.1"]]
   :profiles
-  {:provided {:dependencies [[org.clojure/clojurescript "1.7.228"]]}
+  {:provided {:dependencies [[org.clojure/clojurescript "1.9.908"]]}
    :dev {:source-paths   ["dev/src/clj"]
          :resource-paths ["dev/resources" "target/js"]
          :dependencies [[reloaded.repl "0.2.3"]
                         [ring-jetty-component "0.3.1"]
                         [compojure "1.5.1"]
-                        [figwheel "0.5.8"]
+                        [figwheel "0.5.14"]
                         [org.clojure/tools.nrepl "0.2.12"]]
          :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}})

--- a/src/duct/component/figwheel.clj
+++ b/src/duct/component/figwheel.clj
@@ -66,8 +66,8 @@
 
 (defn- prep-build [{:keys [compiler-env source-paths] :as build}]
   (-> build
-      (cond-> (fig-config/prepped? build) fig-config/prep-build)
-      (cond-> (not compiler-env)          fig-build/add-compiler-env)
+      (cond-> (not (fig-config/prepped? build)) fig-config/prep-build)
+      (cond-> (not compiler-env)                fig-build/add-compiler-env)
       (assoc :watcher (watch-paths source-paths))
       (map->FigwheelBuild)))
 


### PR DESCRIPTION
Build prep condition was reversed and this breaks CLJS builds for newer versions of Clojurescript. I ran into this issue while attempting to upgrade an old project which is still using Component based Duct.

Update figwheel version to 0.5.14 as well.
