### PR TITLE
Bump piggieback and nrepl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [suspendable "0.1.1"]
                  [figwheel-sidecar "0.5.14"]
                  [http-kit "2.2.0"]
-                 [com.cemerick/piggieback "0.2.1"]]
+                 [cider/piggieback "0.4.0"]]
   :profiles
   {:provided {:dependencies [[org.clojure/clojurescript "1.9.908"]]}
    :dev {:source-paths   ["dev/src/clj"]
@@ -17,5 +17,5 @@
                         [ring-jetty-component "0.3.1"]
                         [compojure "1.5.1"]
                         [figwheel "0.5.14"]
-                        [org.clojure/tools.nrepl "0.2.12"]]
-         :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}})
+                        [nrepl "0.6.0"]]
+         :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}})

--- a/src/duct/component/figwheel.clj
+++ b/src/duct/component/figwheel.clj
@@ -1,6 +1,6 @@
 (ns duct.component.figwheel
   "A component for running Figwheel servers."
-  (:require [cemerick.piggieback :as piggieback]
+  (:require [cider.piggieback :as piggieback]
             [cljs.repl :as repl]
             [cljs.stacktrace :as stacktrace]
             [clojure.java.io :as io]


### PR DESCRIPTION
Allows using Leiningen 2.9.1.

cljs-repl would need similar upgrade to figwheel-sidecar (https://github.com/bhauman/lein-figwheel/pull/730), but changes in this PR should help getting Leiningen 2.9.1 into in older projects.